### PR TITLE
availability cleanup

### DIFF
--- a/hotel-data-swagger.yaml
+++ b/hotel-data-swagger.yaml
@@ -341,23 +341,17 @@ components:
               type: integer
           
     Availability:
-      description: Availability data. We're keeping them nested to make the future extension easier.
-      type: object
-      properties:
-        latestSnapshot:
-          $ref: '#/components/schemas/AvailabilitySnapshot'
-    AvailabilitySnapshot:
       description: Full snapshot of availability in time of `updatedAt`
       type: object
       required:
       - updatedAt
-      - availability
+      - roomTypes
       properties:
         updatedAt:
           type: string
           format: date-time
-        availability:
-          description: Object where property names are roomTypeId 
+        roomTypes:
+          description: Object where property names are roomTypeId
           type: object
           additionalProperties:
             type: array


### PR DESCRIPTION
Proposal for availability data structure cleanup

The data structure will not be prepared for possible future enhancements but it will be cleaner and more readable.

Hotel data structure should point to the new Availability object after the change.

We also need to change
- read API
- write API
- Explorer
- anything else?
