### PR TITLE
docs: Adds checklist for env reset into handbooks

### DIFF
--- a/development-handbooks/environment-reset.md
+++ b/development-handbooks/environment-reset.md
@@ -46,3 +46,5 @@ wt-write-api, ...).
 - This might not be necessary if we can transparently describe properties
 of our environments
 - This will probably not work for production-like environment
+- If data format has not changed, you can freely reuse your off chain data. Nothing
+is actually deleted.

--- a/development-handbooks/environment-reset.md
+++ b/development-handbooks/environment-reset.md
@@ -1,0 +1,47 @@
+# Environment reset checklist
+
+This is an extension of
+[technical steps](https://github.com/windingtree/wiki/blob/master/developer-guides/preparing-environment.md#resetting-an-existing-environment)
+and is relevant only to environments managed by Winding Tree. As
+we don't have a production-like environment yet, this all applies
+to every environment considered as
+[*testing*](https://github.com/windingtree/wiki/blob/master/developer-resources.md#publicly-available-wt-deployments).
+
+Our platform is evolving at a rapid pace so inevitably, we are
+introducing breaking changes every so often. Unfortunately, these
+changes also sometimes render existing data incompatible with
+the new platform version.
+
+Goal of this checklist is to help anybody who wants to deploy a new
+version of the environment that is not backwards compatible with the
+existing data. Sometimes it's just easier to start over than to fix
+what we already have.
+
+Even if we specifically declare that both **playground** and **demo**
+can change at any time, we want to keep the surprises to a minimum
+and hopefully keep every interested party in the loop.
+
+## Checklist
+
+- [ ] Decide a date of the reset (deployment of a breaking change).
+- [ ] Inform community about the planned change (Google Group thread,
+more dev channels in the future). The announcement should contain
+information and links to what has changed and how anyone can update
+their integration to adapt (and how can they get help if needed).
+This should go out a few days before the reset.
+- [ ] Create and deploy new iteration of WTIndex.
+- [ ] Document the new WTIndex address. (TODO create a page for this,
+start with work from #60)
+- [ ] Deploy updated wt-fixtures to the new WTIndex.
+- [ ] Wait for the announced date.
+- [ ] Deploy all up-to-date tooling in said envirnoment (wt-read-api,
+wt-write-api, ...).
+- [ ] Update all Winding Tree *satellite* operations (CRON based hotels etc.).
+
+## Notes
+
+- This might evolve into an automated recurring reset (for example once a month)
+- This might evolve into a release guide for Winding Tree platform as a whole
+- This might not be necessary if we can transparently describe properties
+of our environments
+- This will probably not work for production-like environment

--- a/development-handbooks/environment-reset.md
+++ b/development-handbooks/environment-reset.md
@@ -29,7 +29,8 @@ more dev channels in the future). The announcement should contain
 information and links to what has changed and how anyone can update
 their integration to adapt (and how can they get help if needed).
 This should go out a few days before the reset.
-- [ ] Create and deploy new iteration of WTIndex.
+- [ ] Create and deploy new iteration of WTIndex. Don't forget to set up
+Lif token address (migration in wt-contracts does that for you).
 - [ ] Document the new WTIndex address in
 [deployments](https://github.com/windingtree/wiki/blob/master/deployments.md)
 page. We might want to keep the old index addresses there as well.

--- a/development-handbooks/environment-reset.md
+++ b/development-handbooks/environment-reset.md
@@ -5,7 +5,7 @@ This is an extension of
 and is relevant only to environments managed by Winding Tree. As
 we don't have a production-like environment yet, this all applies
 to every environment considered as
-[*testing*](https://github.com/windingtree/wiki/blob/master/developer-resources.md#publicly-available-wt-deployments).
+[*testing*](https://github.com/windingtree/wiki/blob/master/deployments.md).
 
 Our platform is evolving at a rapid pace so inevitably, we are
 introducing breaking changes every so often. Unfortunately, these
@@ -24,8 +24,9 @@ and hopefully keep every interested party in the loop.
 ## Checklist
 
 - [ ] Decide a date of the reset (deployment of a breaking change).
-- [ ] Inform community about the planned change (Google Group thread,
-more dev channels in the future). The announcement should contain
+- [ ] Inform community about the planned change (
+[Google Group](https://groups.google.com/forum/#!forum/windingtree) thread,
+[Gitter](https://gitter.im/windingtree/Lobby)). The announcement should contain
 information and links to what has changed and how anyone can update
 their integration to adapt (and how can they get help if needed).
 This should go out a few days before the reset.
@@ -33,7 +34,7 @@ This should go out a few days before the reset.
 Lif token address (migration in wt-contracts does that for you).
 - [ ] Document the new WTIndex address in
 [deployments](https://github.com/windingtree/wiki/blob/master/deployments.md)
-page. We might want to keep the old index addresses there as well.
+page. We want to keep the old index addresses there as well.
 - [ ] Deploy updated wt-fixtures to the new WTIndex.
 - [ ] Wait for the announced date.
 - [ ] Deploy all up-to-date tooling in said envirnoment (wt-read-api,

--- a/development-handbooks/environment-reset.md
+++ b/development-handbooks/environment-reset.md
@@ -30,8 +30,9 @@ information and links to what has changed and how anyone can update
 their integration to adapt (and how can they get help if needed).
 This should go out a few days before the reset.
 - [ ] Create and deploy new iteration of WTIndex.
-- [ ] Document the new WTIndex address. (TODO create a page for this,
-start with work from #60)
+- [ ] Document the new WTIndex address in
+[deployments](https://github.com/windingtree/wiki/blob/master/deployments.md)
+page. We might want to keep the old index addresses there as well.
 - [ ] Deploy updated wt-fixtures to the new WTIndex.
 - [ ] Wait for the announced date.
 - [ ] Deploy all up-to-date tooling in said envirnoment (wt-read-api,


### PR DESCRIPTION
Continuation and formalization of our internal discussions about how to proceed with the post-hackathon backwards-incompatible environment reset.

This will conflict with #60, I'll resolve that before merging.