### PR TITLE
docs: Initial proposal of the airline data structure

### DIFF
--- a/airlines-data-swagger.yaml
+++ b/airlines-data-swagger.yaml
@@ -187,6 +187,7 @@ components:
                     - availabilityCount
                   properties:
                     fare:
+                      description: Fare price, potentially expressed in multiple currencies.
                       type: array
                       items:
                         $ref: '#/components/schemas/Fare'

--- a/airlines-data-swagger.yaml
+++ b/airlines-data-swagger.yaml
@@ -52,7 +52,7 @@ components:
           $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         flightsUri:
           $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
-          description: URI pointing to Flights data resource
+          description: URI pointing to FlightUris data resource
         bookingUri:
           $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
           description: URI pointing to an instance of the WT Booking service.
@@ -137,19 +137,24 @@ components:
               arrivalAirport:
                 description: IATA code of the arrival airport.
                 $ref: '#/components/schemas/AirportCodeType'
-    Flights:
+    FlightUris:
       type: object
       description: A mapping of flight numbers to flight detail URIs.
       properties:
         uris:
           type: object
-          description: Object where property names are flight numbers and values are URIs serving the Flight data resource.
+          description: Object where property names are flight numbers and values are URIs serving the Flights data resource.
           additionalProperties:
             $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         updatedAt:
           description: Time of the last update of flight information.
           type: string
           format: date-time
+    Flights:
+      description: Array of flight instances for a specific flight number.
+      type: array
+      items:
+        $ref: '#/components/schemas/Flight'
     Flight:
       type: object
       description: Data for a specific flight.
@@ -164,7 +169,7 @@ components:
           format: date-time
         segments:
           description: |
-            An object whose keys are segment IDs (they should match the IDs in the Flight Number data).
+            An object whose keys are segment IDs (they should match the IDs in the FlightNumber data).
             It specifies information for individual flight segments for the given flight.
           type: object
           additionalProperties:

--- a/airlines-data-swagger.yaml
+++ b/airlines-data-swagger.yaml
@@ -19,13 +19,13 @@ components:
       properties:
         address:
           description: Ethereum address of the airline
-          $ref: '#/components/schemas/EthereumAddressType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/EthereumAddressType'
         manager:
           description: Ethereum address of the manager wallet
-          $ref: '#/components/schemas/EthereumAddressType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/EthereumAddressType'
         dataUri:
           description: URI of the Airline data index (pointing off-chain)
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         created:
           description: Number of a block when the hotel was created
           type: integer
@@ -46,15 +46,15 @@ components:
           maxLength: 20
         descriptionUri:
           description: URI pointing to the AirlineDescription data resource
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         servicesUri:
           description: URI pointing to Services data resource
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         flightsUri:
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
           description: URI pointing to Flights data resource
         bookingUri:
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
           description: URI pointing to an instance of the WT Booking service.
     AirlineDescription:
       title: Airline description.
@@ -68,18 +68,18 @@ components:
       properties:
         name:
           description: Name of the airline to display to users
-          $ref: '#/components/schemas/NameType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/NameType'
         code:
           $ref: '#/components/schemas/AirlineCodeType'
         contacts:
           type: object
-          description: List of contacts
+          description: A set of contacts.
           required:
           - general
           properties:
             general:
               description: Primary contact
-              $ref: '#/components/schemas/Contact'
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/Contact'
         updatedAt:
           type: string
           description: Date-time when the data was last changed. Used by consumers to handle incremental updates and caching.
@@ -138,7 +138,7 @@ components:
           type: object
           description: Object where property names are flight numbers and values are URIs serving the Flight data resource.
           additionalProperties:
-            $ref: '#/components/schemas/UriType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         updatedAt:
           description: Time of the last update of flight information.
           type: string
@@ -210,51 +210,9 @@ components:
           format: float
         currency:
           description: Fare price currency.
-          $ref: '#/components/schemas/CurrencyType'
-    Contact:
-      title: Contact
-      type: object
-      properties:
-        email:
-          description: E-mail contact
-          type: string
-          format: email
-          example: joseph.urban@example.com
-          maxLength: 150
-        phone:
-          description: Phone number (with country prefix)
-          type: string
-          maxLength: 18
-          example: +44123456789
-        url:
-          description: Url to the contact web page
-          type: string
-          format: uri
-        ethereum:
-          description: Address of wallet on Ethereum
-          $ref: '#/components/schemas/EthereumAddressType'
-        additionalContacts:
-          description: More contact options, such as Whatsapp, WeChat, Telegram, twitter handle, facebook address. Once we see high demand for a particular type of contact, we can promote them to regular contact types. 
-          type: array
-          items:
-            type: object
-            required:
-            - title
-            - value
-            properties:
-              title:
-                description: Name of this contact options
-                type: string
-              value:
-                description: The actual contact
-                type: string
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/CurrencyType'
           
   # elementary schemas
-    NameType:
-      title: Entity name
-      description: Human readable name identifying an entity (shown to users in search results, hotel/room details, etc)
-      type: string
-      maxLength: 150
     AirlineCodeType:
       title: Airline Code.
       description: IATA 2-Letter Airline code.
@@ -267,24 +225,7 @@ components:
       type: string
       minLength: 3
       maxLength: 3
-    UriType:
-      title: URI
-      description: URI for linking resources. The maximal length is 1500 to save space.
-      type: string
-      format: uri
-      maxLength: 1500
-    CurrencyType:
-      title: Currency code
-      type: string
-      minLength: 3
-      maxLength: 3
-      description: Three letter ISO 4217 currency code.
     EquipmentType:
       title: Airline equipment type (aircraft).
       type: string
       maxLength: 255
-    EthereumAddressType:
-      title: Ethereum address
-      type: string
-      description: Ethereum address in hexadecimal format (with leading 0x) or an ENS name.
-      maxLength: 300

--- a/airlines-data-swagger.yaml
+++ b/airlines-data-swagger.yaml
@@ -1,0 +1,289 @@
+openapi: 3.0.0
+servers: []
+info:
+  version: "0.0.1"
+  title: Airline data definitions
+  description: Object definitions for the airline part of the WT platform.
+paths: {}
+components:
+  schemas:
+    AirlineOnChain:
+      title: WT-Index airline record
+      description: Airline record in WT-Index smart contract
+      type: object
+      required:
+      - address
+      - manager
+      - dataUri
+      - created
+      properties:
+        address:
+          description: Ethereum address of the airline
+          $ref: '#/components/schemas/EthereumAddressType'
+        manager:
+          description: Ethereum address of the manager wallet
+          $ref: '#/components/schemas/EthereumAddressType'
+        dataUri:
+          description: URI of the Airline data index (pointing off-chain)
+          $ref: '#/components/schemas/UriType'
+        created:
+          description: Number of a block when the hotel was created
+          type: integer
+
+    # Off chain data formats  
+    AirlineDataIndex:
+      title: Airline data index
+      description: Landing index for airline resources. Link to this document is stored in WT-Index smart contract airline record.
+      type: object
+      required:
+      - dataFormatVersion
+      - descriptionUri
+      properties:
+        dataFormatVersion:
+          description: Version number indicating the data format specification version.
+          type: string
+          format: semver
+          maxLength: 20
+        descriptionUri:
+          description: URI pointing to the AirlineDescription data resource
+          $ref: '#/components/schemas/UriType'
+        servicesUri:
+          description: URI pointing to Services data resource
+          $ref: '#/components/schemas/UriType'
+        flightsUri:
+          $ref: '#/components/schemas/UriType'
+          description: URI pointing to Flights data resource
+        bookingUri:
+          $ref: '#/components/schemas/UriType'
+          description: URI pointing to an instance of the WT Booking service.
+    AirlineDescription:
+      title: Airline description.
+      description: Basic properties of an airline.
+      type: object
+      required:
+      - name
+      - code
+      - contacts
+      - updatedAt
+      properties:
+        name:
+          description: Name of the airline to display to users
+          $ref: '#/components/schemas/NameType'
+        code:
+          $ref: '#/components/schemas/AirlineCodeType'
+        contacts:
+          type: object
+          description: List of contacts
+          required:
+          - general
+          properties:
+            general:
+              description: Primary contact
+              $ref: '#/components/schemas/Contact'
+        updatedAt:
+          type: string
+          description: Date-time when the data was last changed. Used by consumers to handle incremental updates and caching.
+          format: date-time
+    Services:
+      type: object
+      description: A set of airline services.
+      properties:
+        flightNumbers:
+          type: object
+          description: Object where property names are flight numbers.
+          additionalProperties:
+            $ref: '#/components/schemas/FlightNumber'
+    FlightNumber:
+      type: object
+      description: A single airline service.
+      required:
+        - origin
+        - destination
+        - segments
+      properties:
+        origin:
+          description: IATA code of the origin airport.
+          $ref: '#/components/schemas/AirportCodeType'
+        destination:
+          description: IATA code of the destination airport.
+          $ref: '#/components/schemas/AirportCodeType'
+        equipmentType:
+          $ref: '#/components/schemas/EquipmentType'
+        operatingAirline:
+          $ref: '#/components/schemas/AirlineCodeType'
+        segments:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+              - id
+              - departureAirport
+              - arrivalAirport
+            properties:
+              id:
+                title: ID of the flight segment (must be unique for the given flight number).
+                type: string
+              departureAirport:
+                description: IATA code of the departure airport.
+                $ref: '#/components/schemas/AirportCodeType'
+              arrivalAirport:
+                description: IATA code of the arrival airport.
+                $ref: '#/components/schemas/AirportCodeType'
+    Flights:
+      type: object
+      description: A mapping of flight numbers to flight detail URIs.
+      properties:
+        uris:
+          type: object
+          description: Object where property names are flight numbers and values are URIs serving the Flight data resource.
+          additionalProperties:
+            $ref: '#/components/schemas/UriType'
+        updatedAt:
+          description: Time of the last update of flight information.
+          type: string
+          format: date-time
+    Flight:
+      type: object
+      description: Data for a specific flight.
+      required:
+        - dateTime
+        - segments
+        - updatedAt
+      properties:
+        dateTime:
+          description: Date and time of departure from the first segment
+          type: string
+          format: date-time
+        segments:
+          description: |
+            An object whose keys are segment IDs (they should match the IDs in the Flight Number data).
+            It specifies information for individual flight segments for the given flight.
+          type: object
+          additionalProperties:
+            type: object
+            required:
+              - departureDateTime
+              - arrivalDateTime
+              - bookingClasses
+            properties:
+              departureDateTime:
+                description: Time of the departure.
+                type: string
+                format: date-time
+              arrivalDateTime:
+                description: Time of the arrival.
+                type: string
+                format: date-time
+              bookingClassess:
+                description: |
+                  Object whose keys are class names/codes and values are price
+                  and availability information for the given booking class.
+                type: object
+                additionalProperties:
+                  type: object
+                  required:
+                    - fare
+                    - availabilityCount
+                  properties:
+                    fare:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/Fare'
+                    availabilityCount:
+                      type: integer
+                      format: int32
+        updatedAt:
+          description: Time of the last update of flight information.
+          type: string
+          format: date-time
+    Fare:
+      type: object
+      required:
+        - amount
+        - currency
+      properties:
+        amount:
+          description: Fare price for the flight segment.
+          type: number
+          format: float
+        currency:
+          description: Fare price currency.
+          $ref: '#/components/schemas/CurrencyType'
+    Contact:
+      title: Contact
+      type: object
+      properties:
+        email:
+          description: E-mail contact
+          type: string
+          format: email
+          example: joseph.urban@example.com
+          maxLength: 150
+        phone:
+          description: Phone number (with country prefix)
+          type: string
+          maxLength: 18
+          example: +44123456789
+        url:
+          description: Url to the contact web page
+          type: string
+          format: uri
+        ethereum:
+          description: Address of wallet on Ethereum
+          $ref: '#/components/schemas/EthereumAddressType'
+        additionalContacts:
+          description: More contact options, such as Whatsapp, WeChat, Telegram, twitter handle, facebook address. Once we see high demand for a particular type of contact, we can promote them to regular contact types. 
+          type: array
+          items:
+            type: object
+            required:
+            - title
+            - value
+            properties:
+              title:
+                description: Name of this contact options
+                type: string
+              value:
+                description: The actual contact
+                type: string
+          
+  # elementary schemas
+    NameType:
+      title: Entity name
+      description: Human readable name identifying an entity (shown to users in search results, hotel/room details, etc)
+      type: string
+      maxLength: 150
+    AirlineCodeType:
+      title: Airline Code.
+      description: IATA 2-Letter Airline code.
+      type: string
+      minLength: 2
+      maxLength: 2
+    AirportCodeType:
+      title: Airport Code.
+      description: IATA 3-Letter Airport code.
+      type: string
+      minLength: 3
+      maxLength: 3
+    UriType:
+      title: URI
+      description: URI for linking resources. The maximal length is 1500 to save space.
+      type: string
+      format: uri
+      maxLength: 1500
+    CurrencyType:
+      title: Currency code
+      type: string
+      minLength: 3
+      maxLength: 3
+      description: Three letter ISO 4217 currency code.
+    EquipmentType:
+      title: Airline equipment type (aircraft).
+      type: string
+      maxLength: 255
+    EthereumAddressType:
+      title: Ethereum address
+      type: string
+      description: Ethereum address in hexadecimal format (with leading 0x) or an ENS name.
+      maxLength: 300

--- a/airlines-data-swagger.yaml
+++ b/airlines-data-swagger.yaml
@@ -27,7 +27,7 @@ components:
           description: URI of the Airline data index (pointing off-chain)
           $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         created:
-          description: Number of a block when the hotel was created
+          description: Number of a block when the airline was created
           type: integer
 
     # Off chain data formats  
@@ -147,11 +147,11 @@ components:
       type: object
       description: Data for a specific flight.
       required:
-        - dateTime
+        - departureDateTime
         - segments
         - updatedAt
       properties:
-        dateTime:
+        departureDateTime:
           description: Date and time of departure from the first segment
           type: string
           format: date-time

--- a/airlines-data-swagger.yaml
+++ b/airlines-data-swagger.yaml
@@ -167,6 +167,29 @@ components:
           description: Date and time of departure from the first segment
           type: string
           format: date-time
+        bookingClassess:
+          description: |
+            Object whose keys are class names/codes and values
+            are price and availability information for the given
+            booking class. Currently, price and availability
+            information is provided for the whole flight only.
+            In the future, this information might become more
+            granular (per segment).
+          type: array
+          items:
+            type: object
+            required:
+              - fare
+              - availabilityCount
+            properties:
+              fare:
+                description: Fare price, potentially expressed in multiple currencies.
+                type: array
+                items:
+                  $ref: '#/components/schemas/Fare'
+              availabilityCount:
+                type: integer
+                format: int32
         segments:
           description: |
             An object whose keys are segment IDs (they should match the IDs in the FlightNumber data).
@@ -187,25 +210,6 @@ components:
                 description: Time of the arrival.
                 type: string
                 format: date-time
-              bookingClassess:
-                description: |
-                  Object whose keys are class names/codes and values are price
-                  and availability information for the given booking class.
-                type: object
-                additionalProperties:
-                  type: object
-                  required:
-                    - fare
-                    - availabilityCount
-                  properties:
-                    fare:
-                      description: Fare price, potentially expressed in multiple currencies.
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/Fare'
-                    availabilityCount:
-                      type: integer
-                      format: int32
         updatedAt:
           description: Time of the last update of flight information.
           type: string

--- a/airlines-data-swagger.yaml
+++ b/airlines-data-swagger.yaml
@@ -169,19 +169,32 @@ components:
           format: date-time
         bookingClassess:
           description: |
-            Object whose keys are class names/codes and values
-            are price and availability information for the given
-            booking class. Currently, price and availability
-            information is provided for the whole flight only.
-            In the future, this information might become more
-            granular (per segment).
+            Array of price and availability information for
+            various booking classes of the flight. In the
+            future, this information might become more granular
+            (per segment instead of per flight).
           type: array
           items:
             type: object
             required:
+              - id
+              - name
               - fare
               - availabilityCount
             properties:
+              id:
+                description: |
+                    ID of the booking class to be referenced in
+                    booking requests. Should be unique among all
+                    booking classes of the flight.
+                type: string
+                maxLength: 255
+                example: 'economy'
+              name:
+                description: A human-readable name of the booking class.
+                type: string
+                maxLength: 255
+                example: 'Economy'
               fare:
                 description: Fare price, potentially expressed in multiple currencies.
                 type: array

--- a/airlines-data-swagger.yaml
+++ b/airlines-data-swagger.yaml
@@ -87,12 +87,19 @@ components:
     Services:
       type: object
       description: A set of airline services.
+      required:
+        - updatedAt
+        - flightNumbers
       properties:
         flightNumbers:
           type: object
           description: Object where property names are flight numbers.
           additionalProperties:
             $ref: '#/components/schemas/FlightNumber'
+        updatedAt:
+          description: Time of the last update of services information.
+          type: string
+          format: date-time
     FlightNumber:
       type: object
       description: A single airline service.

--- a/hotel-data-swagger.yaml
+++ b/hotel-data-swagger.yaml
@@ -20,13 +20,13 @@ components:
       properties:
         address:
           description: Ethereum address of the hotel
-          $ref: '#/components/schemas/EthereumAddressType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/EthereumAddressType'
         manager:
           description: Ethereum address of the manager wallet
-          $ref: '#/components/schemas/EthereumAddressType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/EthereumAddressType'
         dataUri:
           description: URI of the Hotel data index (pointing off-chain)
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         created:
           description: Number of a block when the hotel was created
           type: integer
@@ -47,18 +47,18 @@ components:
           maxLength: 20
         descriptionUri:
           description: URI pointing to the HotelDescription data resource
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         ratePlansUri:
           description: URI pointing to RatePlans data resource
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         availabilityUri:
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
           description: URI pointing to Availability data resource
         notificationsUri:
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
           description: URI pointing to an instance of the WT Notification service.
         bookingUri:
-          $ref: '#/components/schemas/UriType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
           description: URI pointing to an instance of the WT Booking service.
 
     HotelDescription:
@@ -85,10 +85,10 @@ components:
           $ref: '#/components/schemas/Location'
         name:
           description: Name of the hotel to display to users
-          $ref: '#/components/schemas/NameType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/NameType'
         description:
           description: Short text description of the hotel to show to users.
-          $ref: '#/components/schemas/DescriptionType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/DescriptionType'
         roomTypes:
           description: Room types in the hotel
           $ref: '#/components/schemas/RoomTypes'
@@ -104,14 +104,14 @@ components:
         address:
           $ref: '#/components/schemas/Address'
         timezone:
-          $ref: '#/components/schemas/TimezoneType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/TimezoneType'
         currency:
-          $ref: '#/components/schemas/CurrencyType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/CurrencyType'
         images:
           description: Images (web browser compatible)
           type: array
           items:
-            $ref: '#/components/schemas/UriType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
         amenities:
           description: Hotel products / services provided for free to guests
           type: array
@@ -149,10 +149,10 @@ components:
       properties:
         name:
           description: Name of the room type to show to users
-          $ref: '#/components/schemas/NameType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/NameType'
         description:
           description: Room type description in plain text
-          $ref: '#/components/schemas/DescriptionType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/DescriptionType'
         totalQuantity:
           type: integer
           format: int32
@@ -184,7 +184,7 @@ components:
           maxItems: 30
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/UriType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/UriType'
             description: image uri
             example: 'https://example.com/my-image.jpg'
         updatedAt:
@@ -233,13 +233,13 @@ components:
       properties:
         name:
           description: Name of the rate plan to show to users
-          $ref: '#/components/schemas/NameType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/NameType'
         description:
           description: Rate plan description in plain text
-          $ref: '#/components/schemas/DescriptionType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/DescriptionType'
         currency:
           description: Currency in which are all the prices of this rate plan. If not set, the hotel currency setting will be used.
-          $ref: '#/components/schemas/CurrencyType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/CurrencyType'
         price:
           type: number
           format: float
@@ -252,7 +252,7 @@ components:
           uniqueItems: true
           items:
             description: RoomType id
-            $ref: '#/components/schemas/ObjectIdType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/ObjectIdType'
             example: '123-afg-34'
         updatedAt:
           type: string
@@ -464,7 +464,7 @@ components:
           format: uri
         ethereum:
           description: Address of wallet on Ethereum
-          $ref: '#/components/schemas/EthereumAddressType'
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/2c6312c06b15a2c12fe764ce10bdb6c4a0f78843/shared-resources.yaml#/components/schemas/EthereumAddressType'
         additionalContacts:
           description: More contact options, such as Whatsapp, WeChat, Telegram, twitter handle, facebook address. Once we see high demand for a particular type of contact, we can promote them to regular contact types. 
           type: array
@@ -509,44 +509,3 @@ components:
           maxLength: 2
           minLength: 2
           description: ISO 3166-1 alpha-2 codes
-          
-  # elementary schemas
-  
-    DescriptionType:
-      title: Markdown description
-      description: Text description in simple Markdown format (bold, italic, titles, line break and paragraph format). Particular flavour of markdown is yet to be decided.
-      type: string
-      maxLength: 3000
-    NameType:
-      title: Entity name
-      description: Human readable name identifying an entity (shown to users in search results, hotel/room details, etc)
-      type: string
-      maxLength: 150
-    ObjectIdType:
-      title: ID
-      description: Vendor string ID
-      type: string
-      maxLength: 100
-      example: '1234-abcd'
-    UriType:
-      title: URI
-      description: URI for linking resources. The maximal length is 1500 to save space.
-      type: string
-      format: uri
-      maxLength: 1500
-    CurrencyType:
-      title: Currency code
-      type: string
-      minLength: 3
-      maxLength: 3
-      description: Three letter ISO 4217 currency code.
-    TimezoneType:
-      title: Timezone code
-      description: Timezone name according to https://www.iana.org/time-zones (refer to zone.tab)
-      type: string
-      maxLength: 40
-    EthereumAddressType:
-      title: Ethereum address
-      type: string
-      description: Ethereum address in hexadecimal format (with leading 0x) or an ENS name.
-      maxLength: 300

--- a/hotel-data-swagger.yaml
+++ b/hotel-data-swagger.yaml
@@ -3,7 +3,7 @@ servers: []
 info:
   version: "0.1.0"
   title: Hotel definitions
-  description: Object definitions for hotel API
+  description: Object definitions for the hotel part of the WT platform.
 paths: {}
 components:
   schemas:
@@ -94,7 +94,7 @@ components:
           $ref: '#/components/schemas/RoomTypes'
         contacts:
           type: object
-          description: List of contacts
+          description: A set of contacts
           required:
           - general
           properties:

--- a/shared-resources.yaml
+++ b/shared-resources.yaml
@@ -58,10 +58,6 @@ components:
       description: Text description in simple Markdown format (bold, italic, titles, line break and paragraph format). Particular flavour of markdown is yet to be decided.
       type: string
       maxLength: 3000
-    EquipmentType:
-      title: Airline equipment type (aircraft).
-      type: string
-      maxLength: 255
     EthereumAddressType:
       title: Ethereum address
       type: string

--- a/shared-resources.yaml
+++ b/shared-resources.yaml
@@ -1,0 +1,91 @@
+openapi: 3.0.0
+servers: []
+info:
+  version: "0.0.1"
+  title: Shared WT data definitions
+  description: Object definitions shared across Winding Tree domains.
+paths: {}
+components:
+  schemas:
+    # Composed schemas
+    Contact:
+      title: Contact
+      type: object
+      properties:
+        email:
+          description: E-mail contact
+          type: string
+          format: email
+          example: joseph.urban@example.com
+          maxLength: 150
+        phone:
+          description: Phone number (with country prefix)
+          type: string
+          maxLength: 18
+          example: +44123456789
+        url:
+          description: Url to the contact web page
+          type: string
+          format: uri
+        ethereum:
+          description: Address of wallet on Ethereum
+          $ref: '#/components/schemas/EthereumAddressType'
+        additionalContacts:
+          description: More contact options, such as Whatsapp, WeChat, Telegram, twitter handle, facebook address. Once we see high demand for a particular type of contact, we can promote them to regular contact types. 
+          type: array
+          items:
+            type: object
+            required:
+            - title
+            - value
+            properties:
+              title:
+                description: Name of this contact options
+                type: string
+              value:
+                description: The actual contact
+                type: string
+
+    # Elementary schemas
+    CurrencyType:
+      title: Currency code
+      type: string
+      minLength: 3
+      maxLength: 3
+      description: Three letter ISO 4217 currency code.
+    DescriptionType:
+      title: Markdown description
+      description: Text description in simple Markdown format (bold, italic, titles, line break and paragraph format). Particular flavour of markdown is yet to be decided.
+      type: string
+      maxLength: 3000
+    EquipmentType:
+      title: Airline equipment type (aircraft).
+      type: string
+      maxLength: 255
+    EthereumAddressType:
+      title: Ethereum address
+      type: string
+      description: Ethereum address in hexadecimal format (with leading 0x) or an ENS name.
+      maxLength: 300
+    NameType:
+      title: Entity name
+      description: Human readable name identifying an entity (shown to users in search results, hotel/room details, etc)
+      type: string
+      maxLength: 150
+    ObjectIdType:
+      title: ID
+      description: Vendor string ID
+      type: string
+      maxLength: 100
+      example: '1234-abcd'
+    TimezoneType:
+      title: Timezone code
+      description: Timezone name according to https://www.iana.org/time-zones (refer to zone.tab)
+      type: string
+      maxLength: 40
+    UriType:
+      title: URI
+      description: URI for linking resources. The maximal length is 1500 to save space.
+      type: string
+      format: uri
+      maxLength: 1500


### PR DESCRIPTION
This PR introduces the initial proposal for the WT airline data structure. The naming convention is inspired by the Open Travel standard (https://schemas.liquid-technologies.com/OpenTravel/2008B/).  Any kind of feedback is welcome.

Once it is merged, we can update the wiki a little to cover airlines alongside hotels in a more systematic way. Together with that, we can prepare the proposition for consultation with our airline mentors.

There is one major thing I suspect cannot stay the way it is in the proposal now, maybe not even temporarily - namely, the prices. Currently, every flight segment has a separate fare with the implicit assumption that the price for a journey that covers multiple flight segments is computed as a sum of the individual flight segment prices. Almost certainly, though, this is not how pricing works in practice.

Aside from that, we are aware that we have "hand-waived" a lot of other pricing problems away for the moment. Maybe it would be good to consider whether we shouldn't take a "hybrid" approach and instead of containing the price information directly in the data structure, hide them beind a "pricingUri" following a similar principle to the existing "bookingUri" (i.e., limit our scope to defining an interface for finding the price for a given query).